### PR TITLE
Use environment variable for admin key

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -68,6 +68,7 @@
    ```bash
    heroku config:set BOT_TOKEN=your_token
    heroku config:set OPENAI_API_KEY=your_key
+   heroku config:set ADMIN_KEY=your_admin_key
    # ... остальные переменные
    ```
 4. **Добавьте Procfile**:
@@ -175,6 +176,7 @@ services:
       - BOT_TOKEN=${BOT_TOKEN}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - ADMIN_CHAT_ID=${ADMIN_CHAT_ID}
+      - ADMIN_KEY=${ADMIN_KEY}
       - PROVIDER_TOKEN=${PROVIDER_TOKEN}
     volumes:
       - ./data:/app/data

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ copy env.example .env
 # Telegram Bot
 BOT_TOKEN=your_bot_token_here
 ADMIN_CHAT_ID=your_admin_chat_id
+ADMIN_KEY=your_admin_key
 
 # OpenAI
 OPENAI_API_KEY=your_openai_api_key_here

--- a/env.example
+++ b/env.example
@@ -6,6 +6,9 @@ BOT_TOKEN=your_bot_token_here
 # ID чата администратора для уведомлений об оплате
 ADMIN_CHAT_ID=your_admin_chat_id_here
 
+# Секретный ключ для админского API
+ADMIN_KEY=your_admin_key_here
+
 # Время debounce в секундах (защита от флуда)
 DEBOUNCE_SECONDS=6
 

--- a/main_enhanced.py
+++ b/main_enhanced.py
@@ -21,6 +21,7 @@ load_dotenv()
 # Конфигурация
 BOT_TOKEN = os.getenv('BOT_TOKEN')
 ADMIN_CHAT_ID = int(os.getenv('ADMIN_CHAT_ID', 0))
+ADMIN_KEY = os.getenv('ADMIN_KEY')
 DEBOUNCE_SECONDS = int(os.getenv('DEBOUNCE_SECONDS', 6))
 MAX_WAIT_SECONDS = int(os.getenv('MAX_WAIT_SECONDS', 15))
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
@@ -572,7 +573,7 @@ def get_users():
     """Получает список пользователей (для админа)"""
     try:
         # Простая проверка авторизации
-        if request.headers.get('X-Admin-Key') != 'admin123':
+        if request.headers.get('X-Admin-Key') != ADMIN_KEY:
             return jsonify({"error": "Unauthorized"}), 401
         
         # Здесь можно добавить логику получения пользователей из БД


### PR DESCRIPTION
## Summary
- Load admin key from `ADMIN_KEY` environment variable and use it in authorization
- Document `ADMIN_KEY` in env example, README, and deployment configs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bab89216308327a1899d6d18f15578