### PR TITLE
Pass max wait to DebounceManager

### DIFF
--- a/main_enhanced.py
+++ b/main_enhanced.py
@@ -28,7 +28,7 @@ PROVIDER_TOKEN = os.getenv('PROVIDER_TOKEN')
 
 # Инициализация компонентов
 app = Flask(__name__)
-debounce_manager = DebounceManager(DEBOUNCE_SECONDS)
+debounce_manager = DebounceManager(DEBOUNCE_SECONDS, MAX_WAIT_SECONDS)
 db_manager = DatabaseManager()
 openai_manager = OpenAIManager(OPENAI_API_KEY)
 bot = Bot(token=BOT_TOKEN)


### PR DESCRIPTION
## Summary
- load MAX_WAIT_SECONDS from environment and pass it to DebounceManager in main_enhanced

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bab84fd9ec8327be3aedba6d6e9cd2